### PR TITLE
Prevent call 'setup' in resize after glide has been destroyed

### DIFF
--- a/src/Glide.js
+++ b/src/Glide.js
@@ -71,6 +71,9 @@ var Glide = function(element, options) {
     this.collect();
     this.setup();
 
+    // Mark the glide as not destroyed
+    this.destroyed = false;
+
     // Call before init callback.
     this.options.beforeInit({
         index: this.current,

--- a/src/modules/Api.js
+++ b/src/modules/Api.js
@@ -141,6 +141,8 @@ var Api = function(Glide, Core) {
                 Core.Arrows.unbind();
                 Core.Bullets.unbind();
 
+                Glide.destroyed = true;
+
                 delete Glide.slider;
                 delete Glide.track;
                 delete Glide.slides;

--- a/src/modules/Events.js
+++ b/src/modules/Events.js
@@ -75,12 +75,14 @@ var Events = function(Glide, Core) {
     Events.prototype.resize = function() {
 
         $(window).on('resize.glide.' + Glide.uuid, Core.Helper.throttle(function() {
-            Core.Transition.jumping = true;
-            Glide.setup();
-            Core.Build.init();
-            Core.Run.make('=' + Glide.current, false);
-            Core.Run.play();
-            Core.Transition.jumping = false;
+            if(!Glide.destroyed) {
+                Core.Transition.jumping = true;
+                Glide.setup();
+                Core.Build.init();
+                Core.Run.make('=' + Glide.current, false);
+                Core.Run.play();
+                Core.Transition.jumping = false;
+            }
         }, Glide.options.throttle));
 
     };


### PR DESCRIPTION
This PR fix a bug when we destroy the glide on resize, today we receive a error because after destroy the glide the `$(window).on('resize.glide...')` are fired and try to setup the glide again

```
Uncaught TypeError: Cannot read property 'length' of undefined   application-7b263cf….js:20 
      glide.setup @ application-7b263cf….js:20
      (anonymous function) @ application-7b263cf….js:20
      (anonymous function) @ application-7b263cf….js:20
      dispatch @ application-7b263cf….js:4
      glide.handle @ application-7b263cf….js:4
```