### PR TITLE
Set padding to 0 on ".glide__track" to prevent a position issue

### DIFF
--- a/src/less/glide.core.less
+++ b/src/less/glide.core.less
@@ -19,6 +19,7 @@
 		transform-style: preserve-3d;
 		touch-action: pan-Y;
 		overflow: hidden;
+		padding: 0;
 
 		&.dragging {
 			cursor: grabbing;

--- a/src/sass/glide.core.scss
+++ b/src/sass/glide.core.scss
@@ -19,6 +19,7 @@
 		transform-style: preserve-3d;
 		touch-action: pan-Y;
 		overflow: hidden;
+		padding: 0;
 
 		&.dragging {
 			cursor: grabbing;


### PR DESCRIPTION
Hi!

I *always* have this issue when implementing glide.js (which I think is awesome - thank you for your work!) - the .glide__track `<ul>` gets a padding-left from standard browser styles and/or normalize.css which in turn makes it that in 'carousel' mode, you see the previous image on each slide (see screenshot).

This little line fixes that. There may very well be a reason you didn't add a `padding: 0` yourself, I'm not sure - is there? If yes, could you explain? I may be able to find a different solution. Happy to help, because that little thing bugs me 😛!

[**Screenshot**](http://i.imgur.com/D0TjMuw.jpg) - no custom css, no custom js except the `{ type: 'carousel', autoheight: true }` options, basic glide.js call


